### PR TITLE
Review container setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
           docker exec test-cassandra sh -c "sed 's/authenticator:.*/authenticator: PasswordAuthenticator/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
           docker exec test-cassandra sh -c "sed 's/authorizer:.*/authorizer: CassandraAuthorizer/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
+          docker exec test-cassandra sh -c " echo "cassandra.superuser_setup_delay_ms: 0" >> /etc/cassandra/jvm.options"
           docker exec test-cassandra nodetool flush
           docker restart test-cassandra
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 2 "Startup complete"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,15 +30,8 @@ jobs:
           docker run --name test-cassandra -d -p 9042:9042 \
           -v ${GITHUB_WORKSPACE}/modevo-script/dat/inp/creationSchema.cql:/creationSchema.cql \
           cassandra:3.11
+          docker run --name test-cassandra -d -p 9042:9042 cassandra:3.11
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
-          docker exec test-cassandra sh -c "sed 's/authenticator:.*/authenticator: PasswordAuthenticator/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
-          docker exec test-cassandra sh -c "sed 's/authorizer:.*/authorizer: CassandraAuthorizer/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
-          docker exec test-cassandra sh -c " echo "cassandra.superuser_setup_delay_ms: 0" >> /etc/cassandra/jvm.options"
-          docker exec test-cassandra nodetool flush
-          docker restart test-cassandra
-          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 2 "Startup complete"
-          docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -e "CREATE ROLE usercassandra WITH PASSWORD = 'passwordcassandra' AND LOGIN = true;"
-          docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -e "GRANT ALL PERMISSIONS on ALL KEYSPACES to usercassandra;"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql
       - name: Test and aggregate surefire report
         run: mvn test -Daggregate=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,12 @@ jobs:
           docker run --name test-cassandra -d -p 9042:9042 \
           -v ${GITHUB_WORKSPACE}/modevo-script/dat/inp/creationSchema.cql:/creationSchema.cql \
           cassandra:3.11
-          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1
+          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
           docker exec test-cassandra sh -c "sed 's/authenticator:.*/authenticator: PasswordAuthenticator/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
           docker exec test-cassandra sh -c "sed 's/authorizer:.*/authorizer: CassandraAuthorizer/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
           docker exec test-cassandra nodetool flush
           docker restart test-cassandra
-          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 2
+          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 2 "Startup complete"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -e "CREATE ROLE usercassandra WITH PASSWORD = 'passwordcassandra' AND LOGIN = true;"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -e "GRANT ALL PERMISSIONS on ALL KEYSPACES to usercassandra;"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
           docker run --name test-cassandra -d -p 9042:9042 \
           -v ${GITHUB_WORKSPACE}/modevo-script/dat/inp/creationSchema.cql:/creationSchema.cql \
           cassandra:3.11
-          docker run --name test-cassandra -d -p 9042:9042 cassandra:3.11
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql
       - name: Test and aggregate surefire report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,12 @@ jobs:
           docker run --name test-cassandra -d -p 9042:9042 \
           -v ${GITHUB_WORKSPACE}/modevo-script/dat/inp/creationSchema.cql:/creationSchema.cql \
           cassandra:3.11
-          sleep 3
+          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1
           docker exec test-cassandra sh -c "sed 's/authenticator:.*/authenticator: PasswordAuthenticator/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
           docker exec test-cassandra sh -c "sed 's/authorizer:.*/authorizer: CassandraAuthorizer/' /etc/cassandra/cassandra.yaml > /etc/cassandra/cassandra_temp.yaml && mv /etc/cassandra/cassandra_temp.yaml /etc/cassandra/cassandra.yaml"
           docker exec test-cassandra nodetool flush
           docker restart test-cassandra
-          sleep 15
+          chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 2
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -e "CREATE ROLE usercassandra WITH PASSWORD = 'passwordcassandra' AND LOGIN = true;"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -e "GRANT ALL PERMISSIONS on ALL KEYSPACES to usercassandra;"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql

--- a/modevo-script/src/test/java/test4giis/script/TestExecutionScript.java
+++ b/modevo-script/src/test/java/test4giis/script/TestExecutionScript.java
@@ -23,7 +23,7 @@ import test4giis.modevo.TestUtils;
 
 
 public class TestExecutionScript {
-	private static final String PROPERTIES = "modevo.properties";
+	private static final String PROPERTIES = "src/test/resources/dbconnection.properties";
 	private static CassandraConnection connection;
 	private static final String bmkPath = "dat/bmk/";
 	private static final String outputPath = "dat/out/";

--- a/modevo-script/src/test/resources/dbconnection.properties
+++ b/modevo-script/src/test/resources/dbconnection.properties
@@ -1,5 +1,5 @@
 #Needs to be customized
 ip=localhost
 port=9042
-user=usercassandra
-password=passwordcassandra
+user=user
+password=password

--- a/modevo.properties
+++ b/modevo.properties
@@ -1,4 +1,0 @@
-ip=localhost
-port=9042
-user=
-password=

--- a/modevo.properties
+++ b/modevo.properties
@@ -1,4 +1,4 @@
 ip=localhost
 port=9042
-user=usercassandra
-password=passwordcassandra
+user=
+password=

--- a/setup/wait-container-ready.sh
+++ b/setup/wait-container-ready.sh
@@ -3,7 +3,7 @@
 #by looking for a string in container log
 container=$1
 countertarget=$2
-target="Startup complete"
+target=$3
 
 attempt=0
 while [ $attempt -le 60 ]; do

--- a/setup/wait-container-ready.sh
+++ b/setup/wait-container-ready.sh
@@ -2,17 +2,20 @@
 #Sample approach to wait until a container is ready
 #by looking for a string in container log
 container=$1
-target=$2
+countertarget=$2
+target="Startup complete"
 
 attempt=0
 while [ $attempt -le 60 ]; do
     attempt=$(( $attempt + 1 ))
     echo "Waiting for container ready (attempt: $attempt)..."
     result=$(docker logs $container)
-    if grep -q "$target" <<< $result ; then
-      echo "Container is ready!"
-      exit 0
+    count=$(grep -o "$target" <<< "$result" | wc -l)
+    if [ $count -eq $countertarget ]; then
+        echo "Container is ready!"
+        exit 0
     fi
+    
     sleep 1
 done
 echo "ERROR: Container is not ready after maximum number of attempts"


### PR DESCRIPTION
The container restart and sleeps have been removed. For now, until a Dockerfile is used to override the cassandra configuration file to require credentials, no credentials are needed to access the database in the test workflow in Github actions. 
The modevo.properties have been renamed to dbconnection.properties and relocated to /src/test/resources as it is part of the tests execution. The other modevo.properties that was stored in the root has been removed.