### PR TITLE
Post Migration - Split UT and IT in separate jobs - Sonarqube fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,6 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files-transform"
           restore-artifact-name2: "test-report-files-script"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/download-artifact@v4.1.5
+        if: always()
+        with:
+          name: "test-report-files-transform"
+      - uses: actions/download-artifact@v4.1.5
+        if: always()
+        with:
+          name: "test-report-files-script"
       - name: Aggregated junit html report
         if: always()
         uses: javiertuya/junit-report-action@v1.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,11 +108,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: javiertuya/sonarqube-action@v1.3.1
-        with: 
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files-transform"
       - name: Aggregated junit html report
         if: always()
         uses: javiertuya/junit-report-action@v1.2.0
@@ -139,6 +134,12 @@ jobs:
             **/target/*.log
             **/reports/*.html
             **/reports/*.log    
+      - uses: javiertuya/sonarqube-action@v1.3.1
+        with: 
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          restore-artifact-name1: "test-report-files-transform"
+          restore-artifact-name2: "test-report-files-script"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files-ALL"
+          restore-artifact-name1: "test-report-ALL"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           restore-artifact-name1: "test-report-files-transform"
-          restore-artifact-name2: "test-report-files-script"
       - name: Aggregated junit html report
         if: always()
         uses: javiertuya/junit-report-action@v1.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,8 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-ALL"
+          restore-artifact-name1: "test-report-files-transform"
+          restore-artifact-name2: "test-report-files-script"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,8 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files-transform"
-          restore-artifact-name2: "test-report-files-script"
+          restore-artifact-name1: "test-report-files-script"
+          restore-artifact-name2: "test-report-files-transform"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql
       - name: Test and aggregate surefire report
-        run: mvn test -Daggregate=true -Dtest=* -pl modevo-script -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
+        run: mvn test -Daggregate=true -Dtest=!TestTransform* -pl modevo-script -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
 
       - name: Additional aggregated junit report
         uses: javiertuya/junit-report-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           restore-artifact-name1: "test-report-files-transform"
-          restore-artifact-name2: "test-report-files-script"
+      - uses: javiertuya/sonarqube-action@v1.3.1
+        with: 
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          restore-artifact-name1: "test-report-files-script"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         name: Publish test report files
         uses: actions/upload-artifact@v4
         with:
-          name: "test-report-files"
+          name: "test-report-files-transform"
           path: |
             target/site
             **/target/site/jacoco/jacoco.xml
@@ -92,7 +92,7 @@ jobs:
         name: Publish test report files
         uses: actions/upload-artifact@v4
         with:
-          name: "test-report-files"
+          name: "test-report-files-script"
           path: |
             target/site
             **/target/site/jacoco/jacoco.xml
@@ -110,7 +110,8 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files"
+          restore-artifact-name1: "test-report-files-transform"
+          restore-artifact-name2: "test-report-files-script"
 
   publish-java-snapshot:
     if: ${{ false }}  # disable for now

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,7 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
+          restore-artifact-name1: "test-report-files-transform"
           restore-artifact-name2: "test-report-files-script"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,46 @@ on:
 env:
   TEST_CASSANDRA_PWD: ${RANDOM}${RANDOM}${RANDOM}
 jobs:
-  test-java:
+
+
+  test-transform:
+    runs-on: ubuntu-latest
+    #if: ${{ false }}  # disable for now
+    #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
+    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+      - name: Test transform module and aggregate surefire report
+        run: mvn test -Daggregate=true -Dtest=* -pl modevo-transform -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
+      - name: Additional aggregated junit report
+        uses: javiertuya/junit-report-action@v1
+        with:
+          surefire-files: "**/target/surefire-reports/TEST-*.xml"
+          report-dir: target/site
+
+      - name: Generate report checks
+        if: always()
+        uses: mikepenz/action-junit-report@v4.2.1
+        with:
+          check_name: "test-result"
+          report_paths: "**/surefire-reports/TEST-*.xml"
+          fail_on_failure: 'true'
+
+      - if: always()
+        name: Publish test report files
+        uses: actions/upload-artifact@v4
+        with:
+          name: "test-report-files"
+          path: |
+            target/site
+            **/target/site/jacoco/jacoco.xml
+            **/target/surefire-reports
+  test-script:
     runs-on: ubuntu-latest
     #if: ${{ false }}  # disable for now
     #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
@@ -33,7 +72,7 @@ jobs:
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql
       - name: Test and aggregate surefire report
-        run: mvn test -Daggregate=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
+        run: mvn test -Daggregate=true -Dtest=* -pl modevo-script -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
 
       - name: Additional aggregated junit report
         uses: javiertuya/junit-report-action@v1
@@ -60,7 +99,7 @@ jobs:
             **/target/surefire-reports
 
   sonarqube:
-    needs: [test-java]
+    needs: [test-transform, test-script]
     #if: ${{ false }}  # disable for now
     #This job fails when comming from a dependabot PR (can't read the sonarqube token for security reasons).
     #Links to discussions and workaround at: https://github.com/giis-uniovi/samples-giis-template/issues/4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         if: always()
         uses: mikepenz/action-junit-report@v4.2.1
         with:
-          check_name: "test-result"
+          check_name: "test-result-transform"
           report_paths: "**/surefire-reports/TEST-*.xml"
           fail_on_failure: 'true'
 
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: mikepenz/action-junit-report@v4.2.1
         with:
-          check_name: "test-result"
+          check_name: "test-result-script"
           report_paths: "**/surefire-reports/TEST-*.xml"
           fail_on_failure: 'true'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: '17'
           cache: 'maven'
       - name: Test transform module and aggregate surefire report
-        run: mvn test -Daggregate=true -Dtest=* -pl modevo-transform -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
+        run: mvn test -Dtest=* -pl modevo-transform -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Additional aggregated junit report
         uses: javiertuya/junit-report-action@v1
         with:
@@ -72,7 +72,7 @@ jobs:
           chmod u+x setup/wait-container-ready.sh && ./setup/wait-container-ready.sh test-cassandra 1 "Created default superuser role"
           docker exec test-cassandra cqlsh localhost 9042 -u cassandra -p cassandra -f creationSchema.cql
       - name: Test and aggregate surefire report
-        run: mvn test -Daggregate=true -Dtest=!TestTransform* -pl modevo-script -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
+        run: mvn test -Dtest=!TestTransform* -pl modevo-script -am -Dmaven.test.failure.ignore=true -U --no-transfer-progress
 
       - name: Additional aggregated junit report
         uses: javiertuya/junit-report-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,11 +147,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           restore-artifact-name1: "test-report-files-transform"
-      - uses: javiertuya/sonarqube-action@v1.3.1
-        with: 
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files-script"
+          restore-artifact-name2: "test-report-files-script"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,7 @@ jobs:
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
-          restore-artifact-name1: "test-report-files-transform"
-          restore-artifact-name2: "test-report-files-script"
+          restore-artifact-name1: "test-report-files-ALL"
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,11 +100,13 @@ jobs:
 
   sonarqube:
     needs: [test-transform, test-script]
+    
     #if: ${{ false }}  # disable for now
     #This job fails when comming from a dependabot PR (can't read the sonarqube token for security reasons).
     #Links to discussions and workaround at: https://github.com/giis-uniovi/samples-giis-template/issues/4
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: javiertuya/sonarqube-action@v1.3.1
         with: 
@@ -112,7 +114,32 @@ jobs:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           restore-artifact-name1: "test-report-files-transform"
           restore-artifact-name2: "test-report-files-script"
-
+      - name: Aggregated junit html report
+        if: always()
+        uses: javiertuya/junit-report-action@v1.2.0
+        with:
+          surefire-files: "**/target/surefire-reports/TEST-*.xml"
+          report-dir: target-ALL/site
+          report-title: "Test Report: ALL - Branch: ${{ github.ref_name }} - Run #${{ github.run_number }}"      
+      - name: Index file to html reports
+        run: |
+          echo "<html><head><title>Latest Test Reports</title></head><body>"  > target-ALL/site/index.html
+          echo "<h2>Latest Test Reports - Branch: ${{ github.ref_name }} - Run #${{ github.run_number }}</h2>"  >> target-ALL/site/index.html
+          echo "<p><a href=\"junit-noframes/junit-noframes.html\">Single page reports</a></p>"                  >> target-ALL/site/index.html
+          echo "<p><a href=\"junit-frames/index.html\">Multiple page reports with frames</a></p>"               >> target-ALL/site/index.html
+          echo "</body></html>"                                              >> target-ALL/site/index.html
+      - if: always()
+        name: Publish test report files
+        uses: actions/upload-artifact@v4
+        with:
+          name: "test-report-ALL"
+          path: |
+            target-ALL/site
+            **/target/surefire-reports
+            **/target/*.html
+            **/target/*.log
+            **/reports/*.html
+            **/reports/*.log    
   publish-java-snapshot:
     if: ${{ false }}  # disable for now
     #avoid publishing PRs and dependabot branches

--- a/modevo-script/src/main/java/giis/modevo/migration/script/execution/ScriptExecution.java
+++ b/modevo-script/src/main/java/giis/modevo/migration/script/execution/ScriptExecution.java
@@ -16,7 +16,8 @@ import giis.modevo.migration.script.Script;
 import giis.modevo.migration.script.ScriptException;
 import giis.modevo.migration.script.Select;
 import giis.modevo.model.schema.Column;
-
+import lombok.extern.slf4j.Slf4j;
+@Slf4j
 public class ScriptExecution {
 	private static final String FROM = "FROM ";
 
@@ -27,6 +28,7 @@ public class ScriptExecution {
 	 */
 	public void execute(Script script, CassandraConnection c, String nameKeyspace) {
 		if (!script.isExecutable()) {
+			log.info("Script is not executable");
 			return;
 		}
 		List<For> highLevelFors = script.getForsHigherLevel();

--- a/modevo-transform/src/main/java/giis/modevo/transformations/MainTransformations.java
+++ b/modevo-transform/src/main/java/giis/modevo/transformations/MainTransformations.java
@@ -58,6 +58,7 @@ public class MainTransformations {
 		} catch (IOException e) {
 			throw new DocumentReadException ("Problem reading MoDEvo.properties file. Read "+e);
 		}
+		log.info("ATL properties file loaded");
 		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put(UMLResource.FILE_EXTENSION, new UMLResourceFactoryImpl());
 	}
 	

--- a/modevo-transform/src/test/java/test4giis/modevo/TestTransform.java
+++ b/modevo-transform/src/test/java/test4giis/modevo/TestTransform.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
-public class TestSchemaChanges {
+public class TestTransform {
 	
 	private static final String inputModelsFolderTemp = "target/input-models/";
 	private static final String schema = "schema.xmi";


### PR DESCRIPTION
Now Sonarqube analyzes all the report files, not just the ones from the script module. The artifact test-report-ALL now contains the reports from both module instead of being empty. The clause aggregate=true from the maven executions have been removed as well.