### PR TITLE
Update cassandra driver to apache

### DIFF
--- a/modevo-script/pom.xml
+++ b/modevo-script/pom.xml
@@ -44,9 +44,9 @@
 			<artifactId>lombok</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>com.datastax.oss</groupId>
+		    <groupId>org.apache.cassandra</groupId>
 		    <artifactId>java-driver-core</artifactId>
-		    <version>4.17.0</version>
+		    <version>4.18.1</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
The location of the driver to connect with a cassandra database has been changed to the newest one.