### PR TITLE
Schema modification "RemovePK" supported in creation of data migration script 

### DIFF
--- a/modevo-script/dat/bmk/testCustomV9RemovePK-script.cql
+++ b/modevo-script/dat/bmk/testCustomV9RemovePK-script.cql
@@ -1,0 +1,2 @@
+FOR $1,$2,$3 = SELECT idAuthor, idBook, title FROM table1BeforeChange
+INSERT INTO table1(idAuthor, idBook, title) VALUES ($1, $2, $3);

--- a/modevo-script/dat/inp/creationSchema.cql
+++ b/modevo-script/dat/inp/creationSchema.cql
@@ -185,6 +185,26 @@ CREATE TABLE "testCustomV8JoinColumn".table1 (
 	PRIMARY KEY (idauthor, idbook)
 ) WITH CLUSTERING ORDER BY ( idbook ASC );
 
+-- Export of keyspace testCustomV9RemovePK
+CREATE KEYSPACE "testCustomV9RemovePK"
+WITH durable_writes = true
+AND replication = {
+	'class' : 'SimpleStrategy',
+	'replication_factor' : 1
+};
+
+CREATE TABLE "testCustomV9RemovePK".table1beforechange (
+	idauthor text,
+	idbook text,
+	title text,
+	PRIMARY KEY (idauthor, idbook, title)
+) WITH CLUSTERING ORDER BY ( idbook ASC );
+CREATE TABLE "testCustomV9RemovePK".table1 (
+	idauthor text,
+	idbook text,
+	title text,
+	PRIMARY KEY (idauthor, idbook)
+) WITH CLUSTERING ORDER BY ( idbook ASC );
 
 -- Export of keyspace testMindsV10NewTableMigrationFromOneTable
 CREATE KEYSPACE "testMindsV10NewTableMigrationFromOneTable"

--- a/modevo-script/dat/inp/testCustomV9RemovePK-initDB.cql
+++ b/modevo-script/dat/inp/testCustomV9RemovePK-initDB.cql
@@ -1,0 +1,5 @@
+TRUNCATE "testCustomV9RemovePK".table1beforechange;
+TRUNCATE "testCustomV9RemovePK".table1;
+Insert into "testCustomV9RemovePK".table1beforechange (idauthor, idbook, title) values ('1', '2', 'lotr');
+Insert into "testCustomV9RemovePK".table1beforechange (idauthor, idbook, title) values ('3', '4', 'asoiaf');
+Insert into "testCustomV9RemovePK".table1beforechange (idauthor, idbook, title) values ('5', '6', 'frieren');

--- a/modevo-script/src/main/java/giis/modevo/migration/script/Script.java
+++ b/modevo-script/src/main/java/giis/modevo/migration/script/Script.java
@@ -72,6 +72,9 @@ public class Script {
 			else if (mt.migrationJoinColumn(se)) {
 				scripts.add(migrationJoinColumn (schema, se, mt));
 			}
+			else if (mt.migrationFromRemovePK(se, mt)) {
+				scripts.add(migrationNewTable (schema, se, mt, false));
+			}
 			else {
 				return new ArrayList<>(); //Scenarios not implemented
 			}
@@ -198,7 +201,8 @@ public class Script {
 		return script;
 	}
 	/**
-	 * Creates the script needed for the migration of a new table.
+	 * Creates the script needed for the migration of a new table. This includes the schema modification RemovePK
+	 * as it creates a new table based on the original one but without the removed PK
 	 */
 	private Script migrationNewTableAll(Schema schema, SchemaEvolution se, MigrationTable mt) {
 		log.info("New Table Script from one source table. Target table: %s", mt.getName());

--- a/modevo-script/src/test/java/test4giis/script/TestExecutionScript.java
+++ b/modevo-script/src/test/java/test4giis/script/TestExecutionScript.java
@@ -132,6 +132,10 @@ public class TestExecutionScript {
 	public void testCustomV8JoinColumn () {
 		testScript(name.getMethodName(), connection);	
 	}
+	@Test
+	public void testCustomV9RemovePK () {
+		testScript(name.getMethodName(), connection);	
+	}
 	public static void executeCQLFile(String path){
 	     try{
             // Open the file that is the first 

--- a/modevo-transform/dat/bmk/testCustomV9RemovePK-dataMigration.xmi
+++ b/modevo-transform/dat/bmk/testCustomV9RemovePK-dataMigration.xmi
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <MigrationTable xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns="DataMigration" name="table1">
   <migcol>
-    <ColTo Data="idAuthor" DataTable="table1"/>
+    <ColTo Data="idAuthor" DataTable="table1BeforeChange"/>
     <ColFrom Data="idAuthor" DataTable="table1BeforeChange"/>
   </migcol>
   <migcol>
-    <ColTo Data="idBook" DataTable="table1"/>
+    <ColTo Data="idBook" DataTable="table1BeforeChange"/>
     <ColFrom Data="idBook" DataTable="table1BeforeChange"/>
   </migcol>
   <migcol>
-    <ColTo Data="title" DataTable="table1"/>
+    <ColTo Data="title" DataTable="table1BeforeChange"/>
     <ColFrom Data="title" DataTable="table1BeforeChange"/>
   </migcol>
 </MigrationTable>

--- a/modevo-transform/dat/inp/testCustomV9RemovePK-schema.xmi
+++ b/modevo-transform/dat/inp/testCustomV9RemovePK-schema.xmi
@@ -1,6 +1,6 @@
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="Schema" xsi:schemaLocation="Schema ../../src/main/java/giis/modevo/transformations/atl/Metamodels/Schema.ecore">
   <Table xmi:id="t1"
-      name="table1">
+      name="table1BeforeChange">
   <Column xmi:id="c1"
       name="idAuthor"
       tableColumn="t1"
@@ -21,16 +21,6 @@
       nameAttribute="title"
       key="true"
       nameEntity="Book"/>
-</Table>
-  <Table xmi:id="t2"
-      name="table2">
-  <Column xmi:id="c4"
-      name="idAuthor"
-      tableColumn="t1"
-      nameAttribute="id"
-      key="true"
-      nameEntity="Author"
-      pk="true"/>
 </Table>
 
 </xmi:XMI>

--- a/modevo-transform/src/main/java/giis/modevo/model/datamigration/MigrationTable.java
+++ b/modevo-transform/src/main/java/giis/modevo/model/datamigration/MigrationTable.java
@@ -117,7 +117,6 @@ public class MigrationTable {
 	public boolean migrationFromRemovePK(SchemaEvolution se, MigrationTable mt) {
 		for (SchemaChange sc : se.getChanges()) {
 			if (sc instanceof RemovePK rpk) {
-				rpk.getNamePreviousTable();
 				for (MigrationColumn mc : mt.getMigrationColumns()) {
 					if (mc.getColFrom().getTable().equalsIgnoreCase(rpk.getNamePreviousTable())) {
 						return true;

--- a/modevo-transform/src/main/java/giis/modevo/transformations/atl/RemovePK.atl
+++ b/modevo-transform/src/main/java/giis/modevo/transformations/atl/RemovePK.atl
@@ -7,11 +7,11 @@ rule removePK {
 		j: SchemaEvolution!RemovePK 	
 		using{
 			tableTarget: Schema!Table = Schema!Table.allInstancesFrom('LM') --Main table to get the data is the previous version
-			->any (t | t.name = j.table);
+			->any (t | t.name = j.previous);
 		}
 	to
 		d: DataMigration!MigrationTable(
-			name<- tableTarget.name,
+			name<- j.table,
 			migcol <- tableTarget.Column -> collect (c | thisModule.columnMigRemovePK(c, tableTarget, j.previous))
 		)
 }


### PR DESCRIPTION
The transformation of data migration models that contain the "RemovePK" schema modification into data migration scripts has been added to MoDEvo.
